### PR TITLE
Fix multi doc upload

### DIFF
--- a/domain/entities.go
+++ b/domain/entities.go
@@ -585,10 +585,10 @@ type ModifyRegistrationDataResponse struct {
 }
 
 type DocumentUploadResponse struct {
-	Success                 bool   `json:"success"`
-	Message                 string `json:"message"`
-	Status                  string `json:"status"`
-	ResponseTimeMs          string `json:"response_time_ms"`
-	ReferenceID             string `json:"reference_id"`
-	DocumentID[interface{}] `json:"document_id"`
+	Success        bool        `json:"success"`
+	Message        string      `json:"message"`
+	Status         string      `json:"status"`
+	ResponseTimeMs string      `json:"response_time_ms"`
+	ReferenceID    string      `json:"reference_id"`
+	DocumentID     interface{} `json:"document_id"`
 }

--- a/domain/entities.go
+++ b/domain/entities.go
@@ -585,10 +585,10 @@ type ModifyRegistrationDataResponse struct {
 }
 
 type DocumentUploadResponse struct {
-	Success        bool   `json:"success"`
-	Message        string `json:"message"`
-	Status         string `json:"status"`
-	ResponseTimeMs string `json:"response_time_ms"`
-	ReferenceID    string `json:"reference_id"`
-	DocumentID     string `json:"document_id"`
+	Success                 bool   `json:"success"`
+	Message                 string `json:"message"`
+	Status                  string `json:"status"`
+	ResponseTimeMs          string `json:"response_time_ms"`
+	ReferenceID             string `json:"reference_id"`
+	DocumentID[interface{}] `json:"document_id"`
 }


### PR DESCRIPTION
The `document_id` field can either be a string or an array of strings depending on if you upload one or many documents. To support this I've made the field an empty interface.