### PR TITLE
chore: add dependabot config for Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      # This is the name of the group, it will be used in PR titles and branch names
+      external-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github.com/kappapay/*"
+      kappa-dependencies:
+        patterns:
+          - "github.com/kappapay/*"


### PR DESCRIPTION
Adds a Dependabot config for Go modules, matching the pattern established in ledger#268. Weekly `gomod` updates, grouped into external dependencies and `github.com/kappapay/*` internal dependencies.